### PR TITLE
Release @musica-sacra/loader v1.0.0

### DIFF
--- a/.changeset/deep-emus-stare.md
+++ b/.changeset/deep-emus-stare.md
@@ -1,5 +1,0 @@
----
-"@musica-sacra/loader": major
----
-
-Made cleaner code, css to scss and variable color, added readme and other config, package files

--- a/package-lock.json
+++ b/package-lock.json
@@ -11904,7 +11904,7 @@
     },
     "packages/dummy": {
       "name": "@musica-sacra/dummy",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "ISC",
       "devDependencies": {
         "react": "^19.0.0",

--- a/packages/loader/CHANGELOG.md
+++ b/packages/loader/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @musica-sacra/loader
 
+## 1.0.0
+
+### Major Changes
+
+- cbdb0f5: Made cleaner code, css to scss and variable color, added readme and other config, package files
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@musica-sacra/loader",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Reusable loader component for Musica Sacra web apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Promote @musica-sacra/loader to version 1.0.0 with major changes including code cleanup, migration from CSS to SCSS, variable color usage, and added documentation and configuration files.